### PR TITLE
DCOS secrets client with CRUD operations

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,6 +15,7 @@ type DCOSSecrets interface {
 	GetSecret(store, key string) (*Secret, error)
 	CreateSecret(store, key string, secret *Secret) error
 	UpdateSecret(store, key string, secret *Secret) error
+	CreateOrUpdateSecret(store, key string, secret *Secret) error
 	DeleteSecret(store, key string) error
 }
 

--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -17,7 +18,13 @@ type DCOSSecrets interface {
 	UpdateSecret(store, key string, secret *Secret) error
 	CreateOrUpdateSecret(store, key string, secret *Secret) error
 	DeleteSecret(store, key string) error
+	RevokeSecret(store, key string) error
+	RenewSecret(store, key string, duration int64) error
 }
+
+var (
+	ErrNotImplemented = errors.New("API not implemented")
+)
 
 type secretsClient struct {
 	config     Config

--- a/client.go
+++ b/client.go
@@ -71,7 +71,9 @@ func getTLSConfig(config Config) (*tls.Config, error) {
 	}
 
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("Could not parse any CA certificates")
+	}
 
 	return &tls.Config{
 		RootCAs: caCertPool,
@@ -126,7 +128,7 @@ func (s *secretsClient) apiRequest(method, path string, body, result interface{}
 	// Returning from here on a 401 because the response currently is
 	// a html page which is not an easily parseable text
 	if response.StatusCode == http.StatusUnauthorized {
-		return NewAPIError([]byte("Unauthorized"))
+		return NewAPIError([]byte(http.StatusText(http.StatusUnauthorized)))
 	}
 
 	return apiResponse(response, result)

--- a/client.go
+++ b/client.go
@@ -73,6 +73,14 @@ func (s *secretsClient) apiPut(path string, body, result interface{}) error {
 	return s.apiRequest("PUT", path, body, result)
 }
 
+func (s *secretsClient) apiPatch(path string, body, result interface{}) error {
+	return s.apiRequest("PATCH", path, body, result)
+}
+
+func (s *secretsClient) apiDelete(path string, result interface{}) error {
+	return s.apiRequest("DELETE", path, nil, result)
+}
+
 func (s *secretsClient) apiRequest(method, path string, body, result interface{}) error {
 	var requestBody []byte
 	var err error

--- a/client.go
+++ b/client.go
@@ -1,0 +1,60 @@
+package dsecrets
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type DCOSSecrets interface {
+	GetSecret(path string) (*Secret, error)
+}
+
+type secretsClient struct {
+	config     Config
+	httpClient *http.Client
+}
+
+func NewClient(config Config) (DCOSSecrets, error) {
+	tlsConfig, err := getTLSConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+
+	return &secretsClient{
+		config:     config,
+		httpClient: httpClient,
+	}, nil
+}
+
+func getTLSConfig(config Config) (*tls.Config, error) {
+	if config.Insecure {
+		return &tls.Config{
+			InsecureSkipVerify: true,
+		}, nil
+	}
+
+	if config.CACertFile == "" {
+		return nil, fmt.Errorf("CA certificate file missing")
+	}
+
+	caCert, err := ioutil.ReadFile(config.CACertFile)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to read CA certs. %v", err)
+	}
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	return &tls.Config{
+		RootCAs: caCertPool,
+	}, nil
+}

--- a/client.go
+++ b/client.go
@@ -1,15 +1,21 @@
-package dsecrets
+package api
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 )
 
 type DCOSSecrets interface {
-	GetSecret(path string) (*Secret, error)
+	GetSecret(store, key string) (*Secret, error)
+	CreateSecret(store, key string, secret *Secret) error
+	UpdateSecret(store, key string, secret *Secret) error
+	DeleteSecret(store, key string) error
 }
 
 type secretsClient struct {
@@ -43,7 +49,7 @@ func getTLSConfig(config Config) (*tls.Config, error) {
 	}
 
 	if config.CACertFile == "" {
-		return nil, fmt.Errorf("CA certificate file missing")
+		return nil, fmt.Errorf("CA certificate file missing.")
 	}
 
 	caCert, err := ioutil.ReadFile(config.CACertFile)
@@ -57,4 +63,71 @@ func getTLSConfig(config Config) (*tls.Config, error) {
 	return &tls.Config{
 		RootCAs: caCertPool,
 	}, nil
+}
+
+func (s *secretsClient) apiGet(path string, result interface{}) error {
+	return s.apiRequest("GET", path, nil, result)
+}
+
+func (s *secretsClient) apiPut(path string, body, result interface{}) error {
+	return s.apiRequest("PUT", path, body, result)
+}
+
+func (s *secretsClient) apiRequest(method, path string, body, result interface{}) error {
+	var requestBody []byte
+	var err error
+
+	if body != nil {
+		if requestBody, err = json.Marshal(body); err != nil {
+			return err
+		}
+	}
+
+	request, err := s.buildJSONRequest(method, path, bytes.NewReader(requestBody))
+	if err != nil {
+		return err
+	}
+
+	response, err := s.httpClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	responseBody, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode >= 200 && response.StatusCode <= 299 {
+		if result != nil {
+			if err := json.Unmarshal(responseBody, result); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	return NewAPIError(responseBody)
+}
+
+type JWTToken struct {
+	Token string `json:"token"`
+}
+
+func (s *secretsClient) buildJSONRequest(method string, path string, reader io.Reader) (*http.Request, error) {
+	url := s.config.URL + path
+	request, err := http.NewRequest(method, url, reader)
+	if err != nil {
+		return nil, err
+	}
+
+	if s.config.ACSToken != "" {
+		request.Header.Add("Authorization", "token="+s.config.ACSToken)
+	}
+
+	request.Header.Add("Content-Type", "application/json")
+	request.Header.Add("Accept", "application/json")
+
+	return request, nil
 }

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-package dsecrets
+package api
 
 type Config struct {
 	URL        string

--- a/config.go
+++ b/config.go
@@ -1,15 +1,32 @@
 package api
 
+// Config contains the options needed by the client to connect and authenticate
 type Config struct {
-	URL        string
+
+	// ClusterURL is the base URL of the DC/OS admin router.
+	ClusterURL string
+
+	// Insecure if true, indicates that the client does not verify server's
+	// certificate chain. Not recommended as the connection could be susceptible to
+	// man-in-the-middle attacks. When false, valid CACertFile should be provided.
+	Insecure bool
+
+	// CACertFile is the location of the root certificate authorities that clients
+	// use when verifying server certificates. Not needed when Insecure flag is set.
 	CACertFile string
-	Insecure   bool
-	ACSToken   string
+
+	// ACSToken DC/OS authentication token used to authorize the API calls to the
+	// admin router. Remember, that the DC/OS token expires after some time (five
+	// days by default). So, it is recommended to refrest the token. Use the
+	// GenerateACSToken() method to update the token at regular intervals or on
+	// failure (401 Unauthorized).
+	ACSToken string
 }
 
+// NewDefaultConfig has default options in the config, which can be overwritten
 func NewDefaultConfig() Config {
 	return Config{
-		URL:      "https://master.mesos",
-		Insecure: false,
+		ClusterURL: DefaultClusterURL,
+		Insecure:   false,
 	}
 }

--- a/config.go
+++ b/config.go
@@ -1,0 +1,15 @@
+package dsecrets
+
+type Config struct {
+	URL        string
+	CACertFile string
+	Insecure   bool
+	ACSToken   string
+}
+
+func NewDefaultConfig() Config {
+	return Config{
+		URL:      "https://master.mesos",
+		Insecure: false,
+	}
+}

--- a/error.go
+++ b/error.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type ErrorResponse struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+type APIError struct {
+	message string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API Error: %s", e.message)
+}
+
+func NewAPIError(body []byte) error {
+	message := string(body)
+
+	errResp := new(ErrorResponse)
+	if err := json.Unmarshal(body, errResp); err == nil && errResp.Description != "" {
+		message = errResp.Description
+	}
+
+	return &APIError{
+		message: message,
+	}
+}

--- a/secret.go
+++ b/secret.go
@@ -52,6 +52,19 @@ func (s *secretsClient) UpdateSecret(store, key string, secret *Secret) error {
 	return s.apiPatch(path, secret, nil)
 }
 
+func (s *secretsClient) CreateOrUpdateSecret(store, key string, secret *Secret) error {
+	path, err := s.getSecretsPath(store, key)
+	if err != nil {
+		return err
+	}
+
+	err = s.apiPut(path, secret, nil)
+	if err != nil && strings.Contains(err.Error(), "already exists") {
+		return s.UpdateSecret(store, key, secret)
+	}
+	return err
+}
+
 func (s *secretsClient) DeleteSecret(store, key string) error {
 	path, err := s.getSecretsPath(store, key)
 	if err != nil {

--- a/secret.go
+++ b/secret.go
@@ -41,16 +41,23 @@ func (s *secretsClient) CreateSecret(store, key string, secret *Secret) error {
 	if err != nil {
 		return err
 	}
-
 	return s.apiPut(path, secret, nil)
 }
 
 func (s *secretsClient) UpdateSecret(store, key string, secret *Secret) error {
-	return nil
+	path, err := s.getSecretsPath(store, key)
+	if err != nil {
+		return err
+	}
+	return s.apiPatch(path, secret, nil)
 }
 
 func (s *secretsClient) DeleteSecret(store, key string) error {
-	return nil
+	path, err := s.getSecretsPath(store, key)
+	if err != nil {
+		return err
+	}
+	return s.apiDelete(path, nil)
 }
 
 func (s *secretsClient) getSecretsPath(store, key string) (string, error) {

--- a/secret.go
+++ b/secret.go
@@ -1,0 +1,13 @@
+package dsecrets
+
+type Secret struct {
+	Author      string   `json:"author,omitempty"`
+	Created     string   `json:"created,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Labels      []string `json:"labels,omitempty"`
+	Value       string   `json:"value,omitempty"`
+}
+
+func (s *secretsClient) GetSecret(path string) (*Secret, error) {
+	return &Secret{}, nil
+}

--- a/secret.go
+++ b/secret.go
@@ -73,6 +73,14 @@ func (s *secretsClient) DeleteSecret(store, key string) error {
 	return s.apiDelete(path, nil)
 }
 
+func (s *secretsClient) RevokeSecret(store, key string) error {
+	return ErrNotImplemented
+}
+
+func (s *secretsClient) RenewSecret(store, key string, duration int64) error {
+	return ErrNotImplemented
+}
+
 func (s *secretsClient) getSecretsPath(store, key string) (string, error) {
 	key = strings.TrimSpace(key)
 	if key == "" {

--- a/token.go
+++ b/token.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const (
+	authLoginPath = "/acs/api/v1/auth/login"
+)
+
+// CreateTokenRequest request object to the create token API
+type CreateTokenRequest struct {
+	UID      string `json:"uid,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+// CreateTokenResponse response object from the create token API
+type CreateTokenResponse struct {
+	Token string `json:"token,omitempty"`
+}
+
+type TokenConfig struct {
+	Config
+	// Username username of the user who has access to the APIs. The Username
+	// and Password are needed to generate the DC/OS ACS token.
+	Username string
+
+	// Password password of the user to generate the ACS token.
+	Password string
+}
+
+func DefaultTokenConfig() TokenConfig {
+	return TokenConfig{
+		Config: Config{
+			ClusterURL: DefaultClusterURL,
+			Insecure:   false,
+		},
+	}
+}
+
+// GenerateACSToken creates a new DC/OS token that can be used by API calls
+func GenerateACSToken(config TokenConfig) (string, error) {
+
+	if config.Username == "" || config.Password == "" {
+		return "", fmt.Errorf("Username/password cannot be empty")
+	}
+
+	client, httpErr := newHTTPClient(config)
+	if httpErr != nil {
+		return "", httpErr
+	}
+
+	requestBody, jsonErr := json.Marshal(
+		CreateTokenRequest{
+			UID:      config.Username,
+			Password: config.Password,
+		},
+	)
+	if jsonErr != nil {
+		return "", jsonErr
+	}
+
+	request, err := buildJSONRequest("POST", config.ClusterURL+authLoginPath, bytes.NewReader(requestBody))
+	if err != nil {
+		return "", err
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+
+	result := new(CreateTokenResponse)
+	if err := apiResponse(response, result); err != nil {
+		return "", err
+	}
+
+	return result.Token, nil
+}
+
+func newHTTPClient(config TokenConfig) (*http.Client, error) {
+	tlsConfig, err := getTLSConfig(config.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}, nil
+}


### PR DESCRIPTION
- CRUD operations for dc/os secrets
- auto-refresh token upon failure if creds are given
- either username-password should be given or a valid acs token

```
config := NewDefaultConfig()
config.ACSToken = "token"
config.CACertFile = "location"

client, _ := NewClient(config)

secret, _ := client.GetSecret("", "dev/testsecret")
```

TODO:
- add details to readme
- add more comments
- add build scripts